### PR TITLE
Remove stale jobs during ingestion

### DIFF
--- a/matchai/jobs/database.py
+++ b/matchai/jobs/database.py
@@ -206,6 +206,27 @@ def get_existing_job_uids() -> set[str]:
     return {row[0] for row in rows}
 
 
+def delete_jobs_by_uids(uids: list[str]) -> int:
+    """Delete jobs from the database by their UIDs.
+
+    Args:
+        uids: List of job UIDs to delete.
+
+    Returns:
+        Number of jobs deleted.
+    """
+    if not uids:
+        return 0
+
+    with get_connection() as db:
+        cursor = db.cursor()
+        ph = db.placeholder
+        placeholders = ",".join([ph] * len(uids))
+        cursor.execute(f"DELETE FROM jobs WHERE uid IN ({placeholders})", uids)
+        db.commit()
+        return cursor.rowcount
+
+
 def get_embedded_job_uids() -> set[str]:
     """Get UIDs of jobs that have been successfully embedded to vector store."""
     with get_connection() as db:

--- a/matchai/jobs/embeddings.py
+++ b/matchai/jobs/embeddings.py
@@ -11,6 +11,7 @@ import numpy as np
 from matchai.config import CHROMA_PATH, DATA_DIR, IS_CLOUD
 from matchai.embeddings import (
     VectorRecord,
+    delete_embeddings,
     embed_text_numpy,
     embed_texts_batch_numpy,
     fetch_embeddings,
@@ -161,6 +162,27 @@ def get_existing_embedding_uids() -> set[str]:
         collection = _get_local_chromadb_collection()
         results = collection.get(include=[])
         return set(results["ids"])
+
+
+def delete_job_embeddings(uids: list[str]) -> int:
+    """Delete job embeddings from vector store.
+
+    Args:
+        uids: List of job UIDs whose embeddings should be deleted.
+
+    Returns:
+        Number of embeddings deleted.
+    """
+    if not uids:
+        return 0
+
+    if IS_CLOUD:
+        return delete_embeddings(uids)
+    else:
+        collection = _get_local_chromadb_collection()
+        # ChromaDB delete doesn't return count, but we trust it worked
+        collection.delete(ids=uids)
+        return len(uids)
 
 
 def embed_candidate(profile: CandidateProfile) -> np.ndarray:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -238,8 +238,9 @@ class TestComeetSandboxIntegration:
     @pytest.mark.integration
     def test_fetch_positions_from_sandbox(self):
         """Test fetching real positions from Comeet sandbox."""
-        positions = fetch_positions(COMEET_SANDBOX["uid"], COMEET_SANDBOX["token"])
+        positions, success = fetch_positions(COMEET_SANDBOX["uid"], COMEET_SANDBOX["token"])
 
+        assert success is True
         assert isinstance(positions, list)
         # Sandbox should have at least some test positions
         assert len(positions) >= 0


### PR DESCRIPTION
Delete jobs from DB and vector store when no longer returned by API. Adds safety check to skip deletion if any API call fails.

- Add delete_jobs_by_uids() to database.py
- Add delete_job_embeddings() to embeddings.py
- Update fetch_positions() to return (list, bool) tuple for error signaling
- Add jobs_deleted stat to ingestion results
- Add tests for deletion functionality
